### PR TITLE
Put Japan's tls_auth_name into its own <p>

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -156,7 +156,11 @@
                         <p><strong>IP address:</strong>
                             <br>212.52.0.122
                             <br>2406:ef80:4:1537::1
-                        <textarea readonly rows="3">tls_auth_name: dot-jp.blahdns.com</textarea> port: 853, 443 (Strict SNI, without SNI will drop)
+                        <p>tls_auth_name:
+                            <br>
+                            <textarea readonly rows="1" cols="50">dot-jp.blahdns.com</textarea>port: 853, 443 (Strict
+                            SNI, without SNI will drop)
+                        </p>
                         
                         <h3>DNSCrypt v2</h3>
                         port: 8443


### PR DESCRIPTION
Hello! This commit puts Japan's tls_auth_name into its own p-tag.

Here's what it looks like on the live site:
![image](https://user-images.githubusercontent.com/12563436/223670239-e81fd9f6-851f-4165-b0fa-93c270052eed.png)
Here's what it looks like with this pull request:
![image](https://user-images.githubusercontent.com/12563436/223670307-11e3d709-8625-4920-b752-3a94bde1624f.png)


Closes #280 